### PR TITLE
fix: Button loading

### DIFF
--- a/src/kit/Button.tsx
+++ b/src/kit/Button.tsx
@@ -1,6 +1,7 @@
 import { Button as AntdButton } from 'antd';
 import React, { forwardRef, MouseEvent, ReactNode } from 'react';
 
+import Icon from 'kit/Icon';
 import { ConditionalWrapper } from 'kit/internal/ConditionalWrapper';
 import Tooltip from 'kit/Tooltip';
 
@@ -39,6 +40,7 @@ const Button: React.FC<ButtonProps> = forwardRef(
       hideChildren = false,
       children,
       icon,
+      loading,
       ...props
     }: ButtonProps & CloneElementProps,
     ref,
@@ -47,6 +49,11 @@ const Button: React.FC<ButtonProps> = forwardRef(
     if (className) classes.push(className); // preserve className value set via cloneElement.
     if (props.selected) classes.push(css.selected);
     if (props.column) classes.push(css.column);
+
+    if (loading) {
+      icon = <Icon decorative name="spinner" spin />;
+      children = 'Loading';
+    }
 
     return (
       <ConditionalWrapper
@@ -58,14 +65,10 @@ const Button: React.FC<ButtonProps> = forwardRef(
           size={size}
           tabIndex={props.disabled ? -1 : 0}
           {...props}>
-          {props.loading ? (
-            !hideChildren && children // use antd spinner and styling
-          ) : (
-            <div className={css.content}>
-              {icon && <div className={css.icon}>{icon}</div>}
-              {!hideChildren && children && <div className={css.children}>{children}</div>}
-            </div>
-          )}
+          <div className={css.content}>
+            {icon && <div className={css.icon}>{icon}</div>}
+            {!hideChildren && children && <div className={css.children}>{children}</div>}
+          </div>
         </AntdButton>
       </ConditionalWrapper>
     );

--- a/src/kit/Button.tsx
+++ b/src/kit/Button.tsx
@@ -51,7 +51,7 @@ const Button: React.FC<ButtonProps> = forwardRef(
     if (props.column) classes.push(css.column);
 
     if (loading) {
-      icon = <Icon decorative name="spinner" spin />;
+      icon = <Icon decorative name="spinner" />;
       children = 'Loading';
     }
 

--- a/src/kit/Icon.tsx
+++ b/src/kit/Icon.tsx
@@ -237,6 +237,7 @@ type CommonProps = {
   name: IconName;
   backgroundColor?: React.CSSProperties['backgroundColor']; // currently only supported by Queued
   opacity?: React.CSSProperties['opacity']; // currently only supported by Queued
+  spin?: boolean;
 };
 export type Props = CommonProps &
   XOR<
@@ -256,6 +257,7 @@ const Icon: React.FC<Props> = ({
   showTooltip = false,
   backgroundColor,
   opacity,
+  spin,
 }: Props) => {
   const classes = [css.base];
 
@@ -268,6 +270,7 @@ const Icon: React.FC<Props> = ({
 
   if (size) classes.push(css[size]);
   if (color) classes.push(css[color]);
+  if (spin) classes.push(css.spin);
 
   const icon = (
     // antdicons have aria-labels already

--- a/src/kit/Icon.tsx
+++ b/src/kit/Icon.tsx
@@ -237,7 +237,6 @@ type CommonProps = {
   name: IconName;
   backgroundColor?: React.CSSProperties['backgroundColor']; // currently only supported by Queued
   opacity?: React.CSSProperties['opacity']; // currently only supported by Queued
-  spin?: boolean;
 };
 export type Props = CommonProps &
   XOR<
@@ -257,7 +256,6 @@ const Icon: React.FC<Props> = ({
   showTooltip = false,
   backgroundColor,
   opacity,
-  spin,
 }: Props) => {
   const classes = [css.base];
 
@@ -270,7 +268,8 @@ const Icon: React.FC<Props> = ({
 
   if (size) classes.push(css[size]);
   if (color) classes.push(css[color]);
-  if (spin) classes.push(css.spin);
+
+  if (name === 'spinner') classes.push(css.spin);
 
   const icon = (
     // antdicons have aria-labels already

--- a/src/kit/Icon/Icon.module.scss
+++ b/src/kit/Icon/Icon.module.scss
@@ -57,11 +57,12 @@
   margin-top: 1px;
 }
 .spin {
-  animation-name: spinning;
   animation-duration: 1000ms;
   animation-iteration-count: infinite;
+  animation-name: spinning;
   animation-timing-function: linear;
 }
+
 @keyframes spinning {
   from {
     transform: rotate(0deg);

--- a/src/kit/Icon/Icon.module.scss
+++ b/src/kit/Icon/Icon.module.scss
@@ -57,7 +57,7 @@
   margin-top: 1px;
 }
 .spin {
-  animation-duration: 1000ms;
+  animation-duration: 0.75s;
   animation-iteration-count: infinite;
   animation-name: spinning;
   animation-timing-function: linear;

--- a/src/kit/Icon/Icon.module.scss
+++ b/src/kit/Icon/Icon.module.scss
@@ -56,3 +56,17 @@
 .filter {
   margin-top: 1px;
 }
+.spin {
+  animation-name: spinning;
+  animation-duration: 1000ms;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+@keyframes spinning {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Replacing the antd loading state for Buttons with the UI kit's `Icon` component. Should avoid bug with Button text reported in WEB-1735. 

Also adding `spin` prop to `Icon` to support this. Went with `<Icon decorative name="spinner" spin />` instead of `name="spin-shadow"` or `<Spinner />` because only `name="spinner"` takes the `color` value being used (for example, blue color when Default or Dashed button is hovered).