### PR TITLE
fix: keep the avatar icon shape

### DIFF
--- a/src/kit/Avatar.module.scss
+++ b/src/kit/Avatar.module.scss
@@ -2,6 +2,7 @@
   align-items: center;
   border-radius: 100%;
   display: flex;
+  flex-shrink: 0;
   font-size: 10px;
   font-weight: bold;
   height: 24px;


### PR DESCRIPTION
Avatar icon width changes when navigation bar is collapsed

Old

<img width="85" alt="image" src="https://github.com/determined-ai/determined-ui/assets/109113616/a6683e9c-b508-47e5-97b9-6c100ec02d91">

new

<img width="71" alt="image" src="https://github.com/determined-ai/determined-ui/assets/109113616/e0d1ee51-4b26-4462-93af-fc49bba8b45f">
