### PR TITLE
feat: Add copy-able CodeSample block to UI Kit

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -11,6 +11,7 @@ import Card from 'kit/Card';
 import Checkbox from 'kit/Checkbox';
 import ClipboardButton from 'kit/ClipboardButton';
 import CodeEditor from 'kit/CodeEditor';
+import CodeSample from 'kit/CodeSample';
 import { Column, Columns } from 'kit/Columns';
 import DatePicker from 'kit/DatePicker';
 import Drawer from 'kit/Drawer';
@@ -89,6 +90,7 @@ const ComponentTitles = {
   Checkboxes: 'Checkboxes',
   ClipboardButton: 'ClipboardButton',
   CodeEditor: 'CodeEditor',
+  CodeSample: 'CodeSample',
   Color: 'Color',
   Columns: 'Columns',
   DatePicker: 'DatePicker',
@@ -1165,6 +1167,28 @@ const CodeEditorSection: React.FC = () => {
         />
         <strong>Multiple files, one not finished loading.</strong>
         <UncontrolledCodeEditor />
+      </AntDCard>
+    </ComponentSection>
+  );
+};
+
+const CodeSampleSection: React.FC = () => {
+  return (
+    <ComponentSection id="CodeSample" title="CodeSample">
+      <AntDCard>
+        <p>
+          The <code>CodeSample</code> component contains a block of code (bash, Python, or other)
+          which is displayed for the user to view or copy with a <code>ClipboardButton</code>.
+          Multi-line text is allowed, but single-line text is not wrapped.
+        </p>
+      </AntDCard>
+      <AntDCard title="Usage">
+        <p>
+          The code is passed in the <code>text</code> prop and is not editable by the user.
+        </p>
+        <CodeSample
+          text={'det checkpoint download 20cb2c1f-3390-44d2-93a6-f728c594da8c-f728c594da8c-f728c594da8c\npython3 -c "print(\'hello world\')"'}
+        />
       </AntDCard>
     </ComponentSection>
   );
@@ -3423,6 +3447,7 @@ const Components = {
   Checkboxes: <CheckboxesSection />,
   ClipboardButton: <ClipboardButtonSection />,
   CodeEditor: <CodeEditorSection />,
+  CodeSample: <CodeSampleSection />,
   Color: <ColorSection />,
   Columns: <ColumnsSection />,
   DatePicker: <DatePickerSection />,

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -1187,7 +1187,9 @@ const CodeSampleSection: React.FC = () => {
           The code is passed in the <code>text</code> prop and is not editable by the user.
         </p>
         <CodeSample
-          text={'det checkpoint download 20cb2c1f-3390-44d2-93a6-f728c594da8c-f728c594da8c-f728c594da8c\npython3 -c "print(\'hello world\')"'}
+          text={
+            'det checkpoint download 20cb2c1f-3390-44d2-93a6-f728c594da8c-f728c594da8c-f728c594da8c\npython3 -c "print(\'hello world\')"'
+          }
         />
       </AntDCard>
     </ComponentSection>

--- a/src/kit/CodeSample.module.scss
+++ b/src/kit/CodeSample.module.scss
@@ -1,0 +1,15 @@
+.base {
+  .commandContainer {
+    display: flex;
+    gap: 12px;
+  }
+  .codeSample {
+    background-color: var(--theme-float-strong);
+    border: solid var(--theme-stroke-width) var(--theme-float-border);
+    border-radius: 4px;
+    flex-grow: 1;
+    overflow-x: scroll;
+    padding: 8px;
+    white-space: pre;
+  }
+}

--- a/src/kit/CodeSample.tsx
+++ b/src/kit/CodeSample.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import ClipboardButton from './ClipboardButton';
+import css from './CodeSample.module.scss';
+
+interface Props {
+  text: string;
+}
+
+const CodeSample: React.FC<Props> = ({ text }) => {
+  return (
+    <div className={css.base}>
+      <div className={css.commandContainer}>
+        <code className={css.codeSample}>{text}</code>
+        <div>
+          <ClipboardButton getContent={() => text} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CodeSample;


### PR DESCRIPTION
Prep work for WEB 1677 - a CodeSample component which we can display in three locations which display a copy-able line of code

- Never editable, receives only `text` prop
- Includes a ClipboardButton
- Lines of text don't word-wrap (`white-space: pre`)
- Multi-line text is allowed