### PR TITLE
UI Kit Chart zoom, label fixes

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -25,6 +25,7 @@ import { TypographySize } from 'kit/internal/fonts';
 import Grid from 'kit/internal/Grid';
 import { Log, LogLevel, Note, Serie, XAxisDomain } from 'kit/internal/types';
 import { LineChart } from 'kit/LineChart';
+import { SyncProvider } from 'kit/LineChart/SyncProvider';
 import { useChartGrid } from 'kit/LineChart/useChartGrid';
 import LogViewer from 'kit/LogViewer/LogViewer';
 import Message from 'kit/Message';
@@ -710,6 +711,11 @@ const ChartsSection: React.FC = () => {
 
   const [xAxis, setXAxis] = useState<XAxisDomain>(XAxisDomain.Batches);
   const createChartGrid = useChartGrid();
+  const xRange = {
+    [XAxisDomain.Batches]: [-1, 10] as [number, number],
+    [XAxisDomain.Time]: undefined,
+    [XAxisDomain.Epochs]: undefined,
+  };
   return (
     <ComponentSection id="Charts" title="Charts">
       <AntDCard>
@@ -760,17 +766,15 @@ const ChartsSection: React.FC = () => {
           The component accepts an <code>xRange</code> prop to set a minimum and maximum x value for
           each XAxisDomain.
         </p>
-        <LineChart
-          handleError={handleError}
-          height={250}
-          series={[zeroline]}
-          title="Chart with set range [-1, 10]"
-          xRange={{
-            [XAxisDomain.Batches]: [-1, 10],
-            [XAxisDomain.Time]: undefined,
-            [XAxisDomain.Epochs]: undefined,
-          }}
-        />
+        <SyncProvider xRange={xRange}>
+          <LineChart
+            handleError={handleError}
+            height={250}
+            series={[zeroline]}
+            title="Chart with set range [-1, 10]"
+            xRange={xRange}
+          />
+        </SyncProvider>
       </AntDCard>
       <AntDCard title="Series with single time point">
         <p>

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -700,6 +700,19 @@ const ChartsSection: React.FC = () => {
     name: 'validation.Alt-Line',
   };
 
+  const line4: Serie = {
+    data: {
+      [XAxisDomain.Batches]: [
+        [1, -1000000],
+        [2, 1],
+        [3, 2],
+        [4, 10000],
+        [5, 2000000],
+      ],
+    },
+    name: 'training.Sci-Line',
+  };
+
   const zeroline: Serie = {
     color: '#009BDE',
     data: {
@@ -775,6 +788,18 @@ const ChartsSection: React.FC = () => {
             xRange={xRange}
           />
         </SyncProvider>
+      </AntDCard>
+      <AntDCard title="Series with scientific notation">
+        <p>
+          The component accepts <code>yTickValues</code> prop for y-axis tick values. The default
+          setting uses scientific notation for very small or very large numbers:
+        </p>
+        <LineChart
+          handleError={handleError}
+          height={250}
+          series={[line4]}
+          title="Chart with scientific notation"
+        />
       </AntDCard>
       <AntDCard title="Series with single time point">
         <p>

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -22,13 +22,11 @@ import css from './LineChart.module.scss';
 export const TRAINING_SERIES_COLOR = '#009BDE';
 export const VALIDATION_SERIES_COLOR = '#F77B21';
 
-const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValue) => {
-  return rawValue.map((val) => {
-    if (val === 0) return val;
-    return val > 9_999 || val < -9_999 || (0 < val && val < 0.0001) || (-0.0001 < val && val < 0)
-      ? val.toExponential(2)
-      : val;
-  });
+const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValues) => {
+  const useNotation = !!rawValues.find(
+    (val) => val > 9_999 || val < -9_999 || (0 < val && val < 0.0001) || (-0.0001 < val && val < 0),
+  );
+  return useNotation ? rawValues.map((val) => (val === 0 ? val : val.toExponential(2))) : rawValues;
 };
 
 /**

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useMemo, useState } from 'react';
 import { FixedSizeGrid, GridChildComponentProps } from 'react-window';
 import uPlot, { AlignedData, Plugin } from 'uplot';
 
-import { getCssVar, getTimeTickValues, glasbeyColor } from 'kit/internal/functions';
+import { getTimeTickValues, glasbeyColor } from 'kit/internal/functions';
 import ScaleSelect from 'kit/internal/ScaleSelect';
 import { Scale, Serie, XAxisDomain } from 'kit/internal/types';
 import { UPlotPoint } from 'kit/internal/UPlot/types';
@@ -21,6 +21,15 @@ import css from './LineChart.module.scss';
 
 export const TRAINING_SERIES_COLOR = '#009BDE';
 export const VALIDATION_SERIES_COLOR = '#F77B21';
+
+const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValue) => {
+  return rawValue.map((val) => {
+    if (val === 0) return val;
+    return val > 9_999 || val < -9_999 || (0 < val && val < 0.0001) || (-0.0001 < val && val < 0)
+      ? val.toExponential(2)
+      : val;
+  });
+};
 
 /**
  * @typedef ChartProps {object}
@@ -73,7 +82,7 @@ export const LineChart: React.FC<LineChartProps> = ({
   xLabel,
   xRange: unzoomedXRange,
   yLabel,
-  yTickValues,
+  yTickValues = getScientificNotationTickValues,
 }: LineChartProps) => {
   const series = Loadable.ensureLoadable(propSeries).getOrElse([]);
   const isLoading = Loadable.isLoadable(propSeries) && Loadable.isNotLoaded(propSeries);
@@ -148,7 +157,7 @@ export const LineChart: React.FC<LineChartProps> = ({
     return {
       axes: [
         {
-          font: `12px ${getCssVar('--theme-font-family')}`,
+          font: '12px Inter, Arial, Helvetica, sans-serif, system-ui',
           grid: { show: false },
           incrs:
             xAxis === XAxisDomain.Time
@@ -167,12 +176,13 @@ export const LineChart: React.FC<LineChartProps> = ({
           values: xTickValues,
         },
         {
-          font: `12px ${getCssVar('--theme-font-family')}`,
+          font: '12px Inter, Arial, Helvetica, sans-serif, system-ui',
           grid: { stroke: '#E3E3E3', width: 1 },
           label: yLabel,
           labelGap: 8,
           scale: 'y',
           side: 3,
+          size: 55,
           ticks: { show: false },
           values: yTickValues,
         },

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -71,7 +71,7 @@ export const LineChart: React.FC<LineChartProps> = ({
   title,
   xAxis = XAxisDomain.Batches,
   xLabel,
-  xRange,
+  xRange: unzoomedXRange,
   yLabel,
   yTickValues,
 }: LineChartProps) => {
@@ -79,6 +79,9 @@ export const LineChart: React.FC<LineChartProps> = ({
   const isLoading = Loadable.isLoadable(propSeries) && Loadable.isNotLoaded(propSeries);
 
   const [hiddenSeries, setHiddenSeries] = useState<Record<number, boolean>>({});
+  const [xRange, setXRange] = useState<
+    Record<XAxisDomain, [number, number] | undefined> | undefined
+  >(unzoomedXRange);
 
   const hasPopulatedSeries: boolean = useMemo(
     () => !!series.find((serie) => serie.data[xAxis]?.length),
@@ -178,6 +181,16 @@ export const LineChart: React.FC<LineChartProps> = ({
         drag: { x: true, y: false },
       },
       height: height - (hasPopulatedSeries ? 0 : 20),
+      hooks: {
+        init: [
+          // allow xRange-d chart to zoom
+          (plot: uPlot) =>
+            xRange?.[xAxis] &&
+            plot.hooks.setSelect?.push(() => {
+              setXRange({ ...xRange, [xAxis]: undefined });
+            }),
+        ],
+      },
       key: xRange?.[xAxis]?.[0],
       legend: { show: false },
       plugins,


### PR DESCRIPTION
Three bug fixes for the chart:

- Tiny numbers on axis
- `yTickValues` prop defaults to scientific notation to avoid issues with very large or small numbers. Added example to DesignKit page

<img width="673" alt="Screen Shot 2023-10-27 at 3 42 14 PM" src="https://github.com/determined-ai/determined-ui/assets/643918/962f611a-951a-4e1e-93d5-6aa885208faf">

- When we have a fixed `xRange` prop, zooming to an area of the chart "unlocks" x boundaries. If the chart is inside a `<SyncProvider>`, double-clicking the chart to reset zoom will restore window to its `xRange`